### PR TITLE
Fix/robust branch extraction

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -2,12 +2,12 @@ name: Build
 on:
   push:
     branches:
-      - '*'
+      - 'main'
+      - 'fix/robust-branch-extraction'
 
   pull_request:
     branches:
-      - 'main'
-      - 'fix/robust-branch-extraction'
+      - ''
 
   create:
     tags:

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'fix/robust-branch-extraction'
 
   pull_request:
     branches:
@@ -24,7 +23,7 @@ jobs:
         fetch-depth: 1
     - name: Demo
       id: demo
-      uses: gimlet-io/gimlet-artifact-shipper-action@fix/robust-branch-extraction
+      uses: gimlet-io/gimlet-artifact-shipper-action@main
       with:
         fields: 'docker-image=mycompany/myimage:mytag'
         debug: "true"

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -6,7 +6,8 @@ on:
 
   pull_request:
     branches:
-      - '*'
+      - 'main'
+      - 'fix/robust-branch-extraction'
 
   create:
     tags:

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -24,7 +24,7 @@ jobs:
         fetch-depth: 1
     - name: Demo
       id: demo
-      uses: gimlet-io/gimlet-artifact-shipper-action@main
+      uses: gimlet-io/gimlet-artifact-shipper-action@fix/robust-branch-extraction
       with:
         fields: 'docker-image=mycompany/myimage:mytag'
         debug: "true"

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     branches:
-      - 'main'
+      - '*'
 
   pull_request:
     branches:
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 1
     - name: Demo
       id: demo
-      uses: gimlet-io/gimlet-artifact-shipper-action@v0.3.13
+      uses: gimlet-io/gimlet-artifact-shipper-action@main
       with:
         fields: 'docker-image=mycompany/myimage:mytag'
         debug: "true"

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -6,7 +6,7 @@ on:
 
   pull_request:
     branches:
-      - ''
+      - '*'
 
   create:
     tags:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
         fetch-depth: 1
     - name: Shipping release artifact to Gimlet
       id: shipping
-      uses: gimlet-io/gimlet-artifact-shipper-action@v0.3.14
+      uses: gimlet-io/gimlet-artifact-shipper-action@v0.4.1
       env:
         GIMLET_SERVER: ${{ secrets.GIMLET_SERVER }}
         GIMLET_TOKEN: ${{ secrets.GIMLET_TOKEN }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ COMMIT_COMITTER_EMAIL=$(git log -1 --pretty=format:'%ce')
 COMMIT_CREATED=$(git log -1 --format=%cI)
 
 BRANCH=${GITHUB_HEAD_REF} # For PRs this var has the branch, see https://docs.github.com/en/actions/reference/environment-variables
-if [ -z "$BRANCH" ]; then BRANCH=${GITHUB_REF##*/}; fi
+if [ -z "$BRANCH" ]; then BRANCH=${GITHUB_REF##refs/heads/}; fi
 export GITHUB_BRANCH=$BRANCH
 # TODO check if head sha is better suited for the workflows: https://github.community/t/github-sha-isnt-the-value-expected/17903/2
 
@@ -28,7 +28,7 @@ fi
 
 if [[ $GITHUB_REF == refs/tags/* ]]   # True if $GITHUB_REF starts with a "refs/tags/" (wildcard matching).
 then
-    TAG=${GITHUB_REF##*/}
+    TAG=${GITHUB_REF##refs/tags/}
     EVENT="tag"
 fi
 


### PR DESCRIPTION
Fixing the naive branch extraction code that couldn't deal with branch names with `/` in them.

It only captured the last segment, causing Gimlet deploy policies not trigger.