### PR TITLE
Making sha equals the branch sha for PRs, and not the merge head sha

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 1
     - name: Demo
       id: demo
-      uses: gimlet-io/gimlet-artifact-shipper-action@branch-commit-sha
+      uses: gimlet-io/gimlet-artifact-shipper-action@main
       with:
         fields: 'docker-image=mycompany/myimage:mytag'
         debug: "true"

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 1
     - name: Demo
       id: demo
-      uses: gimlet-io/gimlet-artifact-shipper-action@main
+      uses: gimlet-io/gimlet-artifact-shipper-action@branch-commit-sha
       with:
         fields: 'docker-image=mycompany/myimage:mytag'
         debug: "true"

--- a/action.yaml
+++ b/action.yaml
@@ -9,6 +9,11 @@ inputs:
     description: 'Set it to true if you want to print the artifact instead of shipping it'
     required: false
     default: "false"
+  branchHead:
+    description: |
+      Branch commit sha for PRs. $GITHUB_SHA contains the merge head sha for PRs, which is a sha that Gimlet doesn't know about
+    default: ${{ github.event.pull_request.head.sha }}"
+    required: false
 outputs:
   artifact-id:
     description: 'ID of the created artifact'

--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ inputs:
   branchHead:
     description: |
       Branch commit sha for PRs. $GITHUB_SHA contains the merge head sha for PRs, which is a sha that Gimlet doesn't know about
-    default: ${{ github.event.pull_request.head.sha }}"
+    default: ${{ github.event.pull_request.head.sha }}
     required: false
 outputs:
   artifact-id:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,10 +20,12 @@ export GITHUB_BRANCH=$BRANCH
 # TODO check if head sha is better suited for the workflows: https://github.community/t/github-sha-isnt-the-value-expected/17903/2
 
 EVENT="push"
+SHA=$GITHUB_SHA
 URL="https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
 if [[ -n "$GITHUB_BASE_REF" ]];
 then
     EVENT="pr"
+    SHA=$3
     SOURCE_BRANCH=$GITHUB_BASE_REF
     TARGET_BRANCH=$GITHUB_TARGET_REF
     PR_NUMBER=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
@@ -38,7 +40,7 @@ fi
 
 gimlet artifact create \
 --repository "$GITHUB_REPOSITORY" \
---sha "$GITHUB_SHA" \
+--sha "$SHA" \
 --created "$COMMIT_CREATED" \
 --branch "$BRANCH" \
 --event "$EVENT" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,13 +24,8 @@ SHA=$GITHUB_SHA
 URL="https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
 if [[ -n "$GITHUB_BASE_REF" ]];
 then
-    echo "This is a PR"
-    echo $3
-    echo $INPUT_BRANCHHEAD
-    echo $INPUT_DEBUG
-    echo $INPUT_FIELDS
     EVENT="pr"
-    SHA=$3
+    SHA=$INPUT_BRANCHHEAD
     SOURCE_BRANCH=$GITHUB_BASE_REF
     TARGET_BRANCH=$GITHUB_TARGET_REF
     PR_NUMBER=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
@@ -67,7 +62,7 @@ gimlet artifact add \
 --field "url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
 echo "Attaching custom fields.."
-fields=$(echo $1 | tr ";" "\n")
+fields=$(echo $INPUT_FIELDS | tr ";" "\n")
 for field in $fields
 do
     # Set the delimiter
@@ -95,7 +90,7 @@ echo "Attaching environment variable context.."
 VARS=$(printenv | grep GITHUB | grep -v '=$' | awk '$0="--var "$0')
 gimlet artifact add -f artifact.json $VARS
 
-if [[ "$2" == "true" ]]; then
+if [[ "$INPUT_DEBUG" == "true" ]]; then
     cat artifact.json
     exit 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,9 @@ if [[ -n "$GITHUB_BASE_REF" ]];
 then
     echo "This is a PR"
     echo $3
+    echo $INPUT_BRANCHHEAD
+    echo $INPUT_DEBUG
+    echo $INPUT_FIELDS
     EVENT="pr"
     SHA=$3
     SOURCE_BRANCH=$GITHUB_BASE_REF

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,8 @@ SHA=$GITHUB_SHA
 URL="https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
 if [[ -n "$GITHUB_BASE_REF" ]];
 then
+    echo "This is a PR"
+    echo $3
     EVENT="pr"
     SHA=$3
     SOURCE_BRANCH=$GITHUB_BASE_REF


### PR DESCRIPTION
GITHUB_SHA contains the merge head in case of PR triggered workflows.

That sha is not known hardly anywhere, neither in gimletd. Instead of using that ephemeral sha, we use the branch head sha instead.

This nicely lines up the references in gimletd