### PR TITLE
Update to inject SHA

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -17,6 +17,10 @@ inputs:
     description: 'Set it to true if you want to watch tracking the artifact and wait until got success or error'
     required: false
     default: "false"
+  sha:
+    description: 'The github sha to use. Defaults to the $GITHUB_SHA'
+    required: false
+    default: ''
   timeout:
     description: 'Set the time for wait flag of artifact track'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,8 +20,8 @@ export GITHUB_BRANCH=$BRANCH
 # TODO check if head sha is better suited for the workflows: https://github.community/t/github-sha-isnt-the-value-expected/17903/2
 
 EVENT="push"
-SHA=$GITHUB_SHA
-URL="https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
+SHA=${INPUT_SHA:-$GITHUB_SHA}  # Changed to use input SHA if provided, fallback to GITHUB_SHA
+URL="https://github.com/$GITHUB_REPOSITORY/commit/$SHA"  # Updated to use the SHA variable
 if [[ -n "$GITHUB_BASE_REF" ]];
 then
     EVENT="pr"
@@ -102,7 +102,7 @@ gimlet artifact add \
 --var "OWNER=$GITHUB_REPOSITORY_OWNER" \
 --var "BRANCH=$BRANCH" \
 --var "TAG=$TAG" \
---var "SHA=$GITHUB_SHA" \
+--var "SHA=$SHA" \
 --var "ACTOR=$GITHUB_ACTOR" \
 --var "EVENT=$GITHUB_EVENT_NAME" \
 --var "JOB=$GITHUB_JOB"


### PR DESCRIPTION
For a case where my gimlet config cannot be localized with my application code and I want to use a second repo to contain the config and perform manual triggers by checking out the other repository, I cannot adjust the GITHUB_SHA which affects the templating of the gimlet manifest with the correct image tag.

I am also not adverse to being able to override other GITHUB env vars if necessary